### PR TITLE
Fix TypeError when using --no-size with --viewbox

### DIFF
--- a/src/svgis/svgis.py
+++ b/src/svgis/svgis.py
@@ -516,7 +516,7 @@ class SVGIS:
             self.log.debug('Not including width or height attributes in output')
 
         if kwargs.pop('viewbox', True):
-            viewbox = [dims[0], -dims[3]] + size
+            viewbox = [dims[0], -dims[3]] + [dims[2] - dims[0], dims[3]-dims[1]]
             self.log.debug('drawing with viewbox')
         else:
             viewbox = None


### PR DESCRIPTION
Bug: Using --no-size together with --viewbox raises a TypeError: can only concatenate list (not "NoneType") to list because size is None when --no-size is passed, but the viewbox computation does [dims[0], -dims[3]] + size.

Fix: Compute the viewbox width/height directly from dims instead of relying on the size variable.